### PR TITLE
Implement missing approvals label

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Comma-separated list of (label,condition) tuples for labels introducing a
 condition. Optional. Globing syntax is possible for the label name, as defined
 in [fnmatch].
 
+### `missing_approvals_label`
+Name of a label that this action will set/unset according to the state of
+required approvals. The label will be set if approvals are missing, and unset
+if there are sufficient approvals.
+
 #### Supported conditions
 - `review.approvals>x`: If the label is set in the Pull Request it requires more
   than `x` approving reviews for the action to succeed

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'A GitHub personal access tokens for private repositories'
     required: false
     default: ''
+  missing_approvals_label:
+    description: '(optional) label to be set if the review approval count condition fails'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -25,3 +29,4 @@ runs:
     - ${{ inputs.set_labels }}
     - ${{ inputs.unset_labels }}
     - ${{ inputs.cond_labels }}
+    - ${{ inputs.missing_approvals_label }}


### PR DESCRIPTION
Adds setting a label corresponding to the approvals status.
Supposed to be used as bors "block_label".